### PR TITLE
Update Export-as-individual-images_1.6.ijm

### DIFF
--- a/Export-as-individual-images_1.6.ijm
+++ b/Export-as-individual-images_1.6.ijm
@@ -109,7 +109,7 @@ for (i=0; i<Mylist.length; i++) {
 		
 		if (proceed==1) {
 			print("Processing: "+sname);
-			run("Bio-Formats Importer", "open=[" + Mypath + Mylist[i] +"] autoscale color_mode=Composite view=Hyperstack stack_order=Default series_" + f);
+			run("Bio-Formats Importer", "open=[" + Mypath + Mylist[i] +"] autoscale color_mode=Composite view=Hyperstack stack_order=XYCZT series_" + f);
 			getDimensions(wi, he, ch, sl, fr);
 			if (maxproj=="yes" && sl>1) run("Z Project...", "projection=[Max Intensity]");
 			if (merge=="yes" && ch>1) run("Stack to RGB");


### PR DESCRIPTION
Hi Patrice. This macro has been incredibly useful in my work. I noticed, however, that running this script alters the BioFormat extension default settings in Fiji. This causes the channel information to get scrambled when importing lif files. Changing the stack order to XYCZT series in line 112 resolves this issue.